### PR TITLE
Qunit explicitly exports its log module, so use that.

### DIFF
--- a/tasks/node-qunit.js
+++ b/tasks/node-qunit.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
-	var log = require('../node_modules/qunit/lib/log.js');
 	var qunit = require("qunit");
+	var log = qunit.log;
 
 	grunt.registerMultiTask("node-qunit", "Runs node-qunit ", function() {
 		var done = this.async(),


### PR DESCRIPTION
I ran into an issue on more recent versions of node/npm -- the node-qunit task was requiring qunit's log module through a relative path, and some change or other broke this.

Qunit expicitly exports that module as `qunit.log`, so using that instead seems to fix things.
